### PR TITLE
Update Dockerfile for compatibility with m1 mac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2.1
+
+jobs:
+  build: &build
+    docker:
+      - image: cimg/base:2022.06
+    resource_class: large
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Setup GCloud SDK
+          command: |
+            sh gcloud-sdk-setup.sh
+      - run:
+          name: Build docker image
+          command: |
+            export PATH=${HOME}/google-cloud-sdk/bin:$PATH
+            export DOCKER_SAFE_NAME=${CIRCLE_BRANCH//\//-}-${CIRCLE_SHA1}
+            docker build --rm --tag peachfinance/pubsub-emulator:$DOCKER_SAFE_NAME .
+            docker tag peachfinance/pubsub-emulator:$DOCKER_SAFE_NAME us-docker.pkg.dev/peach-finance/peach-docker/pubsub-emulator:$DOCKER_SAFE_NAME
+            docker tag peachfinance/pubsub-emulator:$DOCKER_SAFE_NAME us-docker.pkg.dev/peach-finance/peach-docker/pubsub-emulator:latest
+      - run:
+          name: Push docker image to GCloud Registry
+          command: |
+            export PATH=${HOME}/google-cloud-sdk/bin:$PATH
+            gcloud auth configure-docker us-docker.pkg.dev
+            export DOCKER_SAFE_NAME=${CIRCLE_BRANCH//\//-}-${CIRCLE_SHA1}
+            docker push us-docker.pkg.dev/peach-finance/peach-docker/pubsub-emulator:$DOCKER_SAFE_NAME
+            docker push us-docker.pkg.dev/peach-finance/peach-docker/pubsub-emulator:latest
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only:
+                - master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:17.0.2 
 
 LABEL app="pubsub-emulator"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM java:jre-alpine
+FROM openjdk:11
 
-MAINTAINER Sascha Hanse <shanse@gmail.com>
 LABEL app="pubsub-emulator"
 
 ENV CLOUDSDK_CORE_DISABLE_PROMPTS 1
 ENV DATA_DIR "/opt/pubsub"
 ENV HOST_PORT 8085
 
-RUN apk add --no-cache curl bash python
+RUN apt-get update && apt-get install --yes curl bash python3
 
 RUN curl https://sdk.cloud.google.com | bash && \
-			/root/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true && \
-			/root/google-cloud-sdk/bin/gcloud components install -q pubsub-emulator beta
+	/root/google-cloud-sdk/bin/gcloud config set disable_usage_reporting true && \
+	/root/google-cloud-sdk/bin/gcloud components install -q pubsub-emulator beta
 
 RUN mkdir -p ${DATA_DIR}
 EXPOSE 8085

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Usage
 
 ```
-$ docker pull knarz/pubsub-emulator:latest
+$ docker pull us-docker.pkg.dev/peach-finance/peach-docker/pubsub-emulator:latest
 $ docker run --rm -ti --name pubsub-emu pubsub
 ```
 
@@ -11,7 +11,7 @@ Or in a `docker-compose.yml`
 
 ```
 pubsub:
-  image: knarz/pubsub-emulator
+  image: us-docker.pkg.dev/peach-finance/peach-docker/pubsub-emulator:latest
 worker:
   build: .
   environment:

--- a/gcloud-sdk-setup.sh
+++ b/gcloud-sdk-setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+sudo apt update && sudo apt install -y lsb-release apt-transport-https
+
+if which gcloud >/dev/null; then
+  echo GCloud found, no need to install
+else
+  export GCLOUD_SDK_PATH=${HOME}/google-cloud-sdk
+  export GCLOUD_FILENAME="google-cloud-sdk-380.0.0-linux-x86_64.tar.gz"
+  curl --retry 3 -o ${HOME}/${GCLOUD_FILENAME} https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${GCLOUD_FILENAME}
+  cd ${HOME}
+  tar zxf ./${GCLOUD_FILENAME}
+
+  echo "Listing the google-cloud-sdk directory"
+  ls -la ${GCLOUD_SDK_PATH}
+
+  chmod +x ${GCLOUD_SDK_PATH}/install.sh
+  ${GCLOUD_SDK_PATH}/install.sh -q
+  ${GCLOUD_SDK_PATH}/bin/gcloud components install beta pubsub-emulator kubectl -q  
+  export PATH=${GCLOUD_SDK_PATH}/bin:${PATH}
+fi
+
+echo -n ${GCLOUD_SERVICE_KEY} | base64 --decode -i > ${HOME}/gcloud-service-key.json
+gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+gcloud auth configure-docker --quiet


### PR DESCRIPTION
Update Docker image to use modern base image and python.

This addresses a bug we were seeing on m1 macs. The image as built from `java:jre-alpine` hangs forever on m1 macs. (i.e., when running `docker run --rm -ti knarz/pubsub-emulator`)

